### PR TITLE
Add unit tests for checkout and promo code hooks

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,16 +1,13 @@
-/** @type {import('jest').Config} */
-const config = {
-  preset: 'ts-jest',
+const nextJest = require('next/jest');
+
+const createJestConfig = nextJest({ dir: './' });
+
+const customJestConfig = {
+  setupFilesAfterEnv: ['./jest.setup.js'],
   testEnvironment: 'jsdom',
   moduleNameMapper: {
     '^@/(.*)$': '<rootDir>/src/$1',
   },
-  transform: {
-    '^.+\\.(ts|tsx)$': ['ts-jest', {
-      tsconfig: 'tsconfig.json',
-    }],
-  },
-  setupFilesAfterEnv: ['./jest.setup.js'],
   testMatch: ['**/__tests__/**/*.test.(ts|tsx)'],
   collectCoverageFrom: [
     'src/**/*.{ts,tsx}',
@@ -20,4 +17,4 @@ const config = {
   ],
 };
 
-module.exports = config;
+module.exports = createJestConfig(customJestConfig);

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,4 +1,5 @@
 // Global setup and mocks for Jest tests
+import '@testing-library/jest-dom/extend-expect';
 
 // Mocking fetch API
 global.fetch = jest.fn();

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev:turbo": "next dev --turbopack",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "jest"
   },
   "dependencies": {
     "@radix-ui/react-icons": "^1.3.2",
@@ -58,6 +59,8 @@
     "eslint-config-next": "15.3.0",
     "jest": "^29.7.0",
     "jest-environment-jsdom": "^29.7.0",
+    "@testing-library/react": "^14.2.1",
+    "@testing-library/jest-dom": "^6.4.2",
     "postcss": "^8.5.3",
     "tailwindcss": "^4.1.3",
     "typescript": "^5"

--- a/src/app/panier/hooks/__tests__/useCheckout.test.tsx
+++ b/src/app/panier/hooks/__tests__/useCheckout.test.tsx
@@ -1,0 +1,81 @@
+import { render, fireEvent, screen, waitFor } from '@testing-library/react';
+import React from 'react';
+import useCheckout from '../useCheckout';
+import { Cart } from '@/app/panier/types';
+import { PromoResult, LoyaltyBenefits, CustomerInfo } from '../types';
+
+function Wrapper({ customerInfo }: { customerInfo: CustomerInfo }) {
+  const cart: Cart = { items: [], subtotal: 0, subtotalCents: 0, total: 0, totalCents: 0 };
+  const promo: PromoResult = { applied: false, code: '', discount: 0, message: '', type: '' };
+  const loyalty: LoyaltyBenefits = { active: false, message: '', discountAmount: 0, rewardType: 'none', orderCount: 0 };
+  const clearCart = jest.fn();
+  const { handleSubmit, errors } = useCheckout(cart, promo, loyalty, customerInfo, clearCart);
+
+  return (
+    <form onSubmit={handleSubmit} data-testid="form">
+      <input name="firstName" defaultValue={customerInfo.firstName} />
+      <input name="lastName" defaultValue={customerInfo.lastName} />
+      <input name="email" defaultValue={customerInfo.email} />
+      <input name="address" defaultValue={customerInfo.address} />
+      <input name="city" defaultValue={customerInfo.city} />
+      <input name="postalCode" defaultValue={customerInfo.postalCode} />
+      <input name="phone" defaultValue={customerInfo.phone} />
+      <button type="submit">Submit</button>
+      <pre data-testid="errors">{JSON.stringify(errors)}</pre>
+    </form>
+  );
+}
+
+describe('useCheckout', () => {
+  it('shows errors when required fields are missing', async () => {
+    const customerInfo: CustomerInfo = {
+      email: '',
+      firstName: '',
+      lastName: '',
+      phone: '',
+      address: '',
+      addressLine2: '',
+      city: '',
+      postalCode: '',
+      country: 'France',
+    };
+
+    render(<Wrapper customerInfo={customerInfo} />);
+
+    fireEvent.submit(screen.getByTestId('form'));
+
+    await waitFor(() => {
+      const errors = JSON.parse(screen.getByTestId('errors').textContent || '{}');
+      expect(errors).toHaveProperty('firstName');
+      expect(errors).toHaveProperty('lastName');
+      expect(errors).toHaveProperty('email');
+      expect(errors).toHaveProperty('address');
+      expect(errors).toHaveProperty('city');
+      expect(errors).toHaveProperty('postalCode');
+      expect(errors).toHaveProperty('phone');
+    });
+  });
+
+  it('validates phone format', async () => {
+    const customerInfo: CustomerInfo = {
+      email: 'john@example.com',
+      firstName: 'John',
+      lastName: 'Doe',
+      phone: '12345',
+      address: '1 rue ici',
+      addressLine2: '',
+      city: 'Paris',
+      postalCode: '75000',
+      country: 'France',
+    };
+
+    render(<Wrapper customerInfo={customerInfo} />);
+
+    fireEvent.submit(screen.getByTestId('form'));
+
+    await waitFor(() => {
+      const errors = JSON.parse(screen.getByTestId('errors').textContent || '{}');
+      expect(errors.phone).toMatch(/Format invalide/);
+    });
+  });
+});

--- a/src/app/panier/hooks/__tests__/usePromoCode.test.tsx
+++ b/src/app/panier/hooks/__tests__/usePromoCode.test.tsx
@@ -1,0 +1,73 @@
+import { render, fireEvent, screen, waitFor } from '@testing-library/react';
+import React from 'react';
+import usePromoCode from '../usePromoCode';
+import { Cart, CustomerInfo } from '@/app/panier/types';
+
+function Wrapper({ cart, customerInfo }: { cart: Cart; customerInfo: CustomerInfo }) {
+  const { promoCode, setPromoCode, promoResult, applyPromo } = usePromoCode(cart, customerInfo);
+
+  return (
+    <form onSubmit={applyPromo} data-testid="form">
+      <input
+        data-testid="promo-input"
+        value={promoCode}
+        onChange={(e) => setPromoCode(e.target.value)}
+      />
+      <button type="submit">Apply</button>
+      <span data-testid="message">{promoResult.message}</span>
+    </form>
+  );
+}
+
+describe('usePromoCode', () => {
+  beforeEach(() => {
+    (fetch as jest.Mock).mockReset();
+  });
+
+  it('does not call API when code is empty', () => {
+    const cart: Cart = { items: [], subtotal: 0, subtotalCents: 0, total: 0, totalCents: 0 };
+    const customerInfo: CustomerInfo = {
+      email: 'john@example.com',
+      firstName: 'John',
+      lastName: 'Doe',
+      phone: '0612345678',
+      address: '1 rue ici',
+      addressLine2: '',
+      city: 'Paris',
+      postalCode: '75000',
+      country: 'France',
+    };
+
+    render(<Wrapper cart={cart} customerInfo={customerInfo} />);
+    fireEvent.submit(screen.getByTestId('form'));
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it('shows message when promo code is invalid', async () => {
+    const cart: Cart = { items: [], subtotal: 0, subtotalCents: 0, total: 0, totalCents: 0 };
+    const customerInfo: CustomerInfo = {
+      email: 'john@example.com',
+      firstName: 'John',
+      lastName: 'Doe',
+      phone: '0612345678',
+      address: '1 rue ici',
+      addressLine2: '',
+      city: 'Paris',
+      postalCode: '75000',
+      country: 'France',
+    };
+
+    (fetch as jest.Mock).mockResolvedValueOnce({
+      json: async () => ({ success: false, valid: false, message: 'Code invalide' }),
+    });
+
+    render(<Wrapper cart={cart} customerInfo={customerInfo} />);
+    fireEvent.change(screen.getByTestId('promo-input'), { target: { value: 'BAD' } });
+    fireEvent.submit(screen.getByTestId('form'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('message').textContent).toBe('Code invalide');
+    });
+    expect(fetch).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary
- add Jest configuration using `next/jest`
- load `@testing-library/jest-dom` in Jest setup
- provide npm test script and dev dependencies for react-testing-library
- create tests for `useCheckout` and `usePromoCode`

## Testing
- `npm test` *(fails: Cannot find module '@testing-library/react')*