### PR TITLE
Use SWR for product page data

### DIFF
--- a/src/app/produits/[slug]/page.tsx
+++ b/src/app/produits/[slug]/page.tsx
@@ -1,8 +1,7 @@
 import React from 'react';
 import { Metadata } from 'next';
-import { getProductBySlug, getRelatedProducts, getCategories } from '@/services/api';
-import { notFound } from 'next/navigation';
-import ProductDetailView from '@/app/produits/[slug]/product-detail-view';
+import { getProductBySlug } from '@/services/api';
+import ProductPageClient from '@/app/produits/[slug]/product-page-client';
 // Importation nécessaire pour les types mais elle n'est pas utilisée directement
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { RichTextContent } from '@/types/product';
@@ -56,43 +55,7 @@ export async function generateMetadata({
 }
 
 export default async function ProductPage({ params }: { params: Promise<{ slug: string }> }) {
-  try {
-    // Attendre les paramètres avant d'utiliser leurs propriétés (Next.js 15)
-    const paramsResolved = await params;
-    const slug = paramsResolved.slug;
-    
-    // Récupérer les informations du produit
-    const product = await getProductBySlug(slug);
-    
-    // Récupérer les catégories
-    const categories = await getCategories();
-    
-    // Récupérer les produits associés
-    // Gérer correctement la catégorie qui peut être un objet ou une chaîne
-    let categoryIds: string[] = [];
-    if (product.category) {
-      if (Array.isArray(product.category)) {
-        // Si c'est un tableau de catégories
-        categoryIds = product.category.map(cat => 
-          typeof cat === 'string' ? cat : cat.id
-        );
-      } else {
-        // Si c'est une seule catégorie (objet ou chaîne)
-        categoryIds = [typeof product.category === 'string' ? product.category : product.category.id];
-      }
-    }
-    
-    const relatedProducts = await getRelatedProducts(product.id, categoryIds, 4);
-    
-    return (
-      <ProductDetailView 
-        product={product} 
-        relatedProducts={relatedProducts}
-        categories={categories} 
-      />
-    );
-  } catch  {
-    // Si le produit n'est pas trouvé, renvoyer une page 404
-    notFound();
-  }
+  const paramsResolved = await params;
+  const slug = paramsResolved.slug;
+  return <ProductPageClient slug={slug} />;
 }

--- a/src/app/produits/[slug]/product-page-client.tsx
+++ b/src/app/produits/[slug]/product-page-client.tsx
@@ -1,0 +1,60 @@
+'use client';
+
+import React, { useMemo } from 'react';
+import useSWR from 'swr';
+import {
+  getProductBySlug,
+  getRelatedProducts,
+  getCategories,
+} from '@/services/api';
+import ProductDetailView from './product-detail-view';
+
+type Props = {
+  slug: string;
+};
+
+export default function ProductPageClient({ slug }: Props) {
+  const {
+    data: product,
+    error: productError,
+  } = useSWR(slug, () => getProductBySlug(slug));
+
+  const {
+    data: categories,
+    error: categoriesError,
+  } = useSWR('categories', getCategories);
+
+  const categoryIds = useMemo(() => {
+    if (!product || !product.category) return [] as string[];
+    if (Array.isArray(product.category)) {
+      return product.category.map((cat) =>
+        typeof cat === 'string' ? cat : cat.id
+      );
+    }
+    return [typeof product.category === 'string' ? product.category : product.category.id];
+  }, [product]);
+
+  const {
+    data: relatedProducts,
+    error: relatedError,
+  } = useSWR(
+    product ? ['related', product.id, ...categoryIds] : null,
+    () => getRelatedProducts(product!.id, categoryIds, 4)
+  );
+
+  if (productError || categoriesError || relatedError) {
+    return <div className="py-12 text-center">Erreur lors du chargement.</div>;
+  }
+
+  if (!product || !categories || !relatedProducts) {
+    return <div className="py-12 text-center">Chargement...</div>;
+  }
+
+  return (
+    <ProductDetailView
+      product={product}
+      relatedProducts={relatedProducts}
+      categories={categories}
+    />
+  );
+}

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -3,6 +3,15 @@ import { Category, Product } from '@/types/product';
 // URL de base de l'API PayloadCMS
 const API_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3001/api';
 
+// Generic fetcher used with SWR
+export async function fetcher<T>(url: string, init?: RequestInit): Promise<T> {
+  const res = await fetch(url, { cache: 'no-store', ...init });
+  if (!res.ok) {
+    throw new Error(`API responded with status: ${res.status}`);
+  }
+  return res.json();
+}
+
 // Données de secours pour les produits en cas d'erreur API
 const fallbackProducts: Product[] = [
   {


### PR DESCRIPTION
## Summary
- add generic `fetcher` helper in API service
- load product data with `useSWR` in a new client component
- simplify product `[slug]` page to render the client component

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*