### PR TITLE
Add http client wrapper

### DIFF
--- a/src/components/Contact/ContactForm.tsx
+++ b/src/components/Contact/ContactForm.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React, { useState } from 'react';
+import httpClient from '@/lib/httpClient';
 import { Button } from '@/components/ui/button';
 import { Textarea } from '@/components/ui/textarea';
 
@@ -33,21 +34,16 @@ const ContactForm = () => {
       setError(null);
       
       // Utiliser l'API de contact
-      const response = await fetch('/api/contact', {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({
+      const data = await httpClient.post<{ success: boolean; error?: string }>(
+        '/api/contact',
+        {
           name,
           email,
-          message
-        }),
-      });
-      
-      const data = await response.json();
-      
-      if (!response.ok) {
+          message,
+        }
+      );
+
+      if (!data.success) {
         throw new Error(data.error || 'Erreur lors de l\'envoi du message');
       }
       

--- a/src/components/CsrfInitializer.tsx
+++ b/src/components/CsrfInitializer.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useEffect } from 'react';
+import httpClient from '@/lib/httpClient';
 
 /**
  * Composant pour initialiser le token CSRF côté serveur
@@ -11,16 +12,7 @@ export default function CsrfInitializer() {
     const initCsrf = async () => {
       try {
         // Appel à l'API CSRF pour générer/renouveler les tokens
-        const response = await fetch('/api/csrf', { 
-          credentials: 'include',
-          cache: 'no-store'
-        });
-        
-        if (!response.ok) {
-          console.error(`Erreur lors de l'initialisation CSRF: ${response.status}`);
-          return;
-        }
-        
+        await httpClient.get('/api/csrf', { cache: 'no-store' });
         console.log('[CSRF] Tokens CSRF côté serveur initialisés avec succès');
       } catch (error) {
         console.error('[CSRF] Erreur lors de l\'initialisation des tokens CSRF:', error);

--- a/src/components/Reviews/ProductReviews.tsx
+++ b/src/components/Reviews/ProductReviews.tsx
@@ -5,6 +5,7 @@ import ReviewForm from './ReviewForm';
 import StarRating from './StarRating';
 import { Button } from '@/components/ui/button';
 import { ReviewType } from './ReviewItem';
+import httpClient from '@/lib/httpClient';
 
 interface ReviewStats {
   averageRating: number;
@@ -34,11 +35,10 @@ const ProductReviews: React.FC<ProductReviewsProps> = ({ productId, initialStats
   const fetchReviews = async () => {
     try {
       setLoading(true);
-      const response = await fetch(`/api/reviews?productId=${productId}`);
-      if (!response.ok) {
-        throw new Error(`Erreur HTTP: ${response.status}`);
-      }
-      const data = await response.json();
+      const data = await httpClient.get<{
+        reviews: ReviewType[];
+        stats: ReviewStats;
+      }>(`/api/reviews?productId=${productId}`);
       console.log('Données détaillées des avis:', data.reviews?.[0]);
       
       // Utiliser les avis traités avec userDisplayName

--- a/src/components/Reviews/ReviewForm.tsx
+++ b/src/components/Reviews/ReviewForm.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import httpClient from '@/lib/httpClient';
 import StarRating from './StarRating';
 import { Button } from '@/components/ui/button';
 import { Textarea } from '@/components/ui/textarea';
@@ -35,21 +36,16 @@ const ReviewForm: React.FC<ReviewFormProps> = ({ productId, onSuccess, onCancel 
         content: content || '(sans commentaire)' 
       });
       
-      const response = await fetch('/api/reviews', {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({
+      const data = await httpClient.post<{ success: boolean; error?: string }>(
+        '/api/reviews',
+        {
           productId,
           rating,
-          reviewContent: content // Le backend gèrera les valeurs vides
-        }),
-      });
-      
-      const data = await response.json();
-      
-      if (!response.ok) {
+          reviewContent: content, // Le backend gèrera les valeurs vides
+        }
+      );
+
+      if (!data.success) {
         console.error('Erreur de soumission:', data);
         throw new Error(data.error || 'Erreur lors de la soumission de l\'avis');
       }

--- a/src/lib/httpClient.ts
+++ b/src/lib/httpClient.ts
@@ -1,0 +1,68 @@
+export interface HttpError extends Error {
+  status?: number;
+  data?: unknown;
+}
+
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3000';
+
+export async function fetchJson<T>(
+  input: RequestInfo | URL,
+  init: RequestInit = {}
+): Promise<T> {
+  const url =
+    typeof input === 'string' && !input.startsWith('http')
+      ? `${API_BASE_URL}${input.startsWith('/') ? '' : '/'}${input}`
+      : input;
+
+  const response = await fetch(url, {
+    credentials: 'include',
+    headers: {
+      'Content-Type': 'application/json',
+      ...(init.headers || {}),
+    },
+    ...init,
+  });
+
+  const text = await response.text();
+  const data: unknown = text ? JSON.parse(text) : null;
+
+  if (!response.ok) {
+    const errorMessage =
+      data && typeof data === 'object' && 'message' in data
+        ? (data as { message?: string }).message
+        : response.statusText;
+    const error: HttpError = new Error(errorMessage || response.statusText);
+    error.status = response.status;
+    error.data = data;
+    throw error;
+  }
+
+  return data as T;
+}
+
+const client = {
+  get: <T>(url: string, init?: RequestInit) =>
+    fetchJson<T>(url, { method: 'GET', ...init }),
+  post: <T, U>(url: string, body: U, init?: RequestInit) =>
+    fetchJson<T>(url, {
+      method: 'POST',
+      body: JSON.stringify(body),
+      ...init,
+    }),
+  put: <T, U>(url: string, body: U, init?: RequestInit) =>
+    fetchJson<T>(url, {
+      method: 'PUT',
+      body: JSON.stringify(body),
+      ...init,
+    }),
+  patch: <T, U>(url: string, body: U, init?: RequestInit) =>
+    fetchJson<T>(url, {
+      method: 'PATCH',
+      body: JSON.stringify(body),
+      ...init,
+    }),
+  delete: <T>(url: string, init?: RequestInit) =>
+    fetchJson<T>(url, { method: 'DELETE', ...init }),
+};
+
+export default client;


### PR DESCRIPTION
## Summary
- create reusable `fetchJson` helper and typed HTTP methods
- refactor API service to use the new http client
- update contact and review forms with helper
- switch CSRF initializer and auth context to use http client

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*