### PR TITLE
[Feature] Centralize HTTP client with axios

### DIFF
--- a/src/app/connexion/page.tsx
+++ b/src/app/connexion/page.tsx
@@ -79,22 +79,19 @@ function LoginForm() {
       logger.debug('[Login Debug] Tentative de connexion avec fetchWithCsrf');
       
       // Utiliser fetchWithCsrf au lieu de fetch standard pour inclure l'en-tête CSRF
-      const response = await fetchWithCsrf('/api/auth/login', {
+      const { data } = await fetchWithCsrf('/auth/login', {
         method: 'POST',
         headers: {
-          'Content-Type': 'application/json',
+          'Content-Type': 'application/json'
         },
         body: JSON.stringify({
           email: formData.email,
           password: formData.password,
           collection: 'customers'
-        }),
-        credentials: 'include' // S'assurer que les cookies sont envoyés
+        })
       });
 
-      const data = await response.json();
-
-      if (!response.ok) {
+      if (data.error) {
         throw new Error(data.error || 'Erreur de connexion');
       }
 

--- a/src/components/Contact/ContactForm.tsx
+++ b/src/components/Contact/ContactForm.tsx
@@ -3,6 +3,7 @@
 import React, { useState } from 'react';
 import { Button } from '@/components/ui/button';
 import { Textarea } from '@/components/ui/textarea';
+import { httpClient } from '@/lib/httpClient';
 
 const ContactForm = () => {
   const [name, setName] = useState('');
@@ -32,24 +33,11 @@ const ContactForm = () => {
       setIsSubmitting(true);
       setError(null);
       
-      // Utiliser l'API de contact
-      const response = await fetch('/api/contact', {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({
-          name,
-          email,
-          message
-        }),
+      await httpClient.post('/contact', {
+        name,
+        email,
+        message
       });
-      
-      const data = await response.json();
-      
-      if (!response.ok) {
-        throw new Error(data.error || 'Erreur lors de l\'envoi du message');
-      }
       
       // Réinitialiser le formulaire après envoi réussi
       setName('');

--- a/src/components/CsrfInitializer.tsx
+++ b/src/components/CsrfInitializer.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect } from 'react';
 import { secureLogger as logger } from '@/utils/logger';
+import { httpClient } from '@/lib/httpClient';
 
 /**
  * Composant pour initialiser le token CSRF côté serveur
@@ -12,16 +13,7 @@ export default function CsrfInitializer() {
     const initCsrf = async () => {
       try {
         // Appel à l'API CSRF pour générer/renouveler les tokens
-        const response = await fetch('/api/csrf', { 
-          credentials: 'include',
-          cache: 'no-store'
-        });
-        
-        if (!response.ok) {
-          console.error(`Erreur lors de l'initialisation CSRF: ${response.status}`);
-          return;
-        }
-        
+        await httpClient.get('/csrf');
         logger.info('[CSRF] Tokens CSRF côté serveur initialisés avec succès');
       } catch (error) {
         console.error('[CSRF] Erreur lors de l\'initialisation des tokens CSRF:', error);

--- a/src/components/Reviews/ProductReviews.tsx
+++ b/src/components/Reviews/ProductReviews.tsx
@@ -6,6 +6,7 @@ import StarRating from './StarRating';
 import { Button } from '@/components/ui/button';
 import { ReviewType } from './ReviewItem';
 import { secureLogger as logger } from '@/utils/logger';
+import { httpClient } from '@/lib/httpClient';
 
 interface ReviewStats {
   averageRating: number;
@@ -35,11 +36,7 @@ const ProductReviews: React.FC<ProductReviewsProps> = ({ productId, initialStats
   const fetchReviews = async () => {
     try {
       setLoading(true);
-      const response = await fetch(`/api/reviews?productId=${productId}`);
-      if (!response.ok) {
-        throw new Error(`Erreur HTTP: ${response.status}`);
-      }
-      const data = await response.json();
+      const { data } = await httpClient.get(`/reviews?productId=${productId}`);
       logger.debug('Données détaillées des avis récupérées');
       
       // Utiliser les avis traités avec userDisplayName

--- a/src/components/Reviews/ReviewForm.tsx
+++ b/src/components/Reviews/ReviewForm.tsx
@@ -3,6 +3,7 @@ import StarRating from './StarRating';
 import { Button } from '@/components/ui/button';
 import { Textarea } from '@/components/ui/textarea';
 import { secureLogger as logger } from '@/utils/logger';
+import { httpClient } from '@/lib/httpClient';
 
 type ReviewFormProps = {
   productId: string;
@@ -35,24 +36,11 @@ const ReviewForm: React.FC<ReviewFormProps> = ({ productId, onSuccess, onCancel 
         rating
       });
       
-      const response = await fetch('/api/reviews', {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({
-          productId,
-          rating,
-          reviewContent: content // Le backend gèrera les valeurs vides
-        }),
+      await httpClient.post('/reviews', {
+        productId,
+        rating,
+        reviewContent: content // Le backend gèrera les valeurs vides
       });
-      
-      const data = await response.json();
-      
-      if (!response.ok) {
-        console.error('Erreur de soumission:', data);
-        throw new Error(data.error || 'Erreur lors de la soumission de l\'avis');
-      }
       
       logger.debug('Avis soumis avec succès');
       

--- a/src/lib/httpClient.ts
+++ b/src/lib/httpClient.ts
@@ -1,0 +1,8 @@
+import axios from 'axios';
+
+export const httpClient = axios.create({
+  baseURL: process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3000/api',
+  withCredentials: true,
+  timeout: 10000,
+});
+

--- a/src/middleware/middleware.ts
+++ b/src/middleware/middleware.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import type { NextRequest } from 'next/server';
 import { validateCsrfToken } from '@/lib/security/csrf';
+import { httpClient } from '@/lib/httpClient';
 
 // Stockage des demandes pour le rate limiting (en production, utiliser Redis)
 type RequestRecord = { count: number; timestamps: number[] };
@@ -235,20 +236,11 @@ export async function middleware(request: NextRequest) {
     
     // Vérifier avec le backend si l'utilisateur est un admin
     try {
-      const response = await fetch(
-        `${process.env.NEXT_PUBLIC_API_URL}/api/auth/me`,
-        { 
-          headers: { 
-            'Authorization': `Bearer ${token}` 
-          } 
+      const { data: payload } = await httpClient.get(`${process.env.NEXT_PUBLIC_API_URL}/auth/me`, {
+        headers: {
+          Authorization: `Bearer ${token}`
         }
-      );
-      
-      if (!response.ok) {
-        return NextResponse.json({ error: 'Unauthorized' }, { status: 403 });
-      }
-      
-      const payload = await response.json();
+      });
       if (!payload?.user || payload.user.collection !== 'admins') {
         return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
       }

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -1,16 +1,5 @@
 import { Category, Product } from '@/types/product';
-
-// URL de base de l'API PayloadCMS
-const API_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3001/api';
-
-// Generic fetcher used with SWR
-export async function fetcher<T>(url: string, init?: RequestInit): Promise<T> {
-  const res = await fetch(url, { cache: 'no-store', ...init });
-  if (!res.ok) {
-    throw new Error(`API responded with status: ${res.status}`);
-  }
-  return res.json();
-}
+import { httpClient } from '@/lib/httpClient';
 
 // Données de secours pour les produits en cas d'erreur API
 const fallbackProducts: Product[] = [
@@ -158,16 +147,7 @@ export async function getProducts(params?: {
     if (params?.maxPrice) queryParams.append('where[price][less_than_equal]', params.maxPrice.toString());
 
     // Tentative de récupération depuis l'API
-    const response = await fetch(`${API_URL}/api/products?${queryParams.toString()}`, {
-      cache: 'no-store', // Utiliser uniquement no-store sans revalidate pour éviter les conflits
-    });
-
-    if (!response.ok) {
-      // Si l'API ne répond pas correctement, utiliser les données de secours
-      throw new Error(`API responded with status: ${response.status}`);
-    }
-
-    const data = await response.json();
+    const { data } = await httpClient.get(`/products?${queryParams.toString()}`);
     return data;
   } catch (error) {
     console.error('Error fetching products:', error);
@@ -226,15 +206,7 @@ export async function getProducts(params?: {
 export async function getProductBySlug(slug: string): Promise<Product> {
   try {
     // Ajouter l'option depth pour récupérer toutes les relations, y compris les statistiques d'avis
-    const response = await fetch(`${API_URL}/api/products?where[slug][equals]=${slug}&depth=2`, {
-      cache: 'no-store', // Utiliser uniquement no-store sans revalidate pour éviter les conflits
-    });
-
-    if (!response.ok) {
-      throw new Error(`API responded with status: ${response.status}`);
-    }
-
-    const data = await response.json();
+    const { data } = await httpClient.get(`/products?where[slug][equals]=${slug}&depth=2`);
     if (!data.docs || data.docs.length === 0) {
       throw new Error('Product not found');
     }
@@ -276,15 +248,7 @@ export async function getProductBySlug(slug: string): Promise<Product> {
  */
 export async function getCategories(): Promise<Category[]> {
   try {
-    const response = await fetch(`${API_URL}/api/categories`, {
-      cache: 'no-store', // Utiliser uniquement no-store sans revalidate pour éviter les conflits
-    });
-
-    if (!response.ok) {
-      throw new Error(`API responded with status: ${response.status}`);
-    }
-
-    const data = await response.json();
+    const { data } = await httpClient.get('/categories');
     return data.docs;
   } catch (error) {
     console.error('Error fetching categories:', error);
@@ -299,15 +263,7 @@ export async function getCategories(): Promise<Category[]> {
  */
 export async function getCategoryBySlug(slug: string): Promise<Category> {
   try {
-    const response = await fetch(`${API_URL}/api/categories?where[slug][equals]=${slug}`, {
-      cache: 'no-store', // Utiliser uniquement no-store sans revalidate pour éviter les conflits
-    });
-
-    if (!response.ok) {
-      throw new Error(`API responded with status: ${response.status}`);
-    }
-
-    const data = await response.json();
+    const { data } = await httpClient.get(`/categories?where[slug][equals]=${slug}`);
     if (!data.docs || data.docs.length === 0) {
       throw new Error('Category not found');
     }
@@ -345,15 +301,7 @@ export async function getRelatedProducts(productId: string, categoryIds: string[
       });
     }
     
-    const response = await fetch(`${API_URL}/api/products?${queryParams.toString()}`, {
-      cache: 'no-store', // Utiliser uniquement no-store sans revalidate pour éviter les conflits
-    });
-
-    if (!response.ok) {
-      throw new Error(`API responded with status: ${response.status}`);
-    }
-
-    const data = await response.json();
+    const { data } = await httpClient.get(`/products?${queryParams.toString()}`);
     return data.docs;
   } catch (error) {
     console.error('Error fetching related products:', error);


### PR DESCRIPTION
## Summary
- add axios-based `httpClient` helper
- refactor `services/api` to use `httpClient`
- migrate fetch calls in reviews, contact form, CSRF initializer, auth context and utilities
- update middleware admin check to use `httpClient`

## Testing
- `pnpm run build` *(fails: Failed to fetch Google Fonts)*