### PR TITLE
[Fix] Simplify middleware without CSRF checks

### DIFF
--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,8 +1,19 @@
 // Global setup and mocks for Jest tests
-import '@testing-library/jest-dom/extend-expect';
+import '@testing-library/jest-dom';
 
 // Mocking fetch API
 global.fetch = jest.fn();
+
+// Ensure Fetch API classes exist for packages depending on them
+if (typeof global.Request === 'undefined') {
+  global.Request = class {};
+}
+if (typeof global.Headers === 'undefined') {
+  global.Headers = class { constructor() {} get() {} append() {} };
+}
+if (typeof global.Response === 'undefined') {
+  global.Response = class {};
+}
 
 // Simulate environment variables
 process.env = {
@@ -44,6 +55,9 @@ global.NextResponse = {
     cookies: mockCookies,
   })),
 };
+
+// Polyfill scrollIntoView for jsdom environment
+Element.prototype.scrollIntoView = jest.fn();
 
 // Cleanup after each test
 afterEach(() => {

--- a/src/app/panier/hooks/__tests__/usePromoCode.test.tsx
+++ b/src/app/panier/hooks/__tests__/usePromoCode.test.tsx
@@ -3,6 +3,11 @@ import React from 'react';
 import usePromoCode from '../usePromoCode';
 import { Cart, CustomerInfo } from '@/app/panier/types';
 
+// Mock fetchWithCsrf to use global fetch for tests
+jest.mock('@/lib/security/csrf', () => ({
+  fetchWithCsrf: (...args: any[]) => fetch(...args).then(res => res.json()),
+}));
+
 function Wrapper({ cart, customerInfo }: { cart: Cart; customerInfo: CustomerInfo }) {
   const { promoCode, setPromoCode, promoResult, applyPromo } = usePromoCode(cart, customerInfo);
 

--- a/src/middleware/__tests__/middleware.test.ts
+++ b/src/middleware/__tests__/middleware.test.ts
@@ -1,0 +1,31 @@
+import { validateCsrfToken } from '@/lib/security/csrf';
+
+jest.mock('next/server', () => ({
+  NextResponse: {
+    json: jest.fn((data) => ({ data })),
+    next: jest.fn(() => ({ next: true })),
+    redirect: jest.fn((url) => ({ redirect: url })),
+  },
+}));
+
+import { middleware } from '../middleware';
+
+jest.mock('@/lib/security/csrf', () => ({
+  validateCsrfToken: jest.fn().mockResolvedValue(true),
+}));
+
+describe('middleware CSRF logic removed', () => {
+  it('does not call validateCsrfToken for POST requests', async () => {
+    const request = {
+      headers: new Headers(),
+      cookies: { get: jest.fn() },
+      nextUrl: new URL('http://localhost/api/test'),
+      url: 'http://localhost/api/test',
+      method: 'POST',
+    } as any;
+
+    await middleware(request);
+
+    expect(validateCsrfToken).not.toHaveBeenCalled();
+  });
+});

--- a/src/middleware/middleware.ts
+++ b/src/middleware/middleware.ts
@@ -1,6 +1,5 @@
 import { NextResponse } from 'next/server';
 import type { NextRequest } from 'next/server';
-import { validateCsrfToken } from '@/lib/security/csrf';
 import { httpClient } from '@/lib/httpClient';
 
 // Stockage des demandes pour le rate limiting (en production, utiliser Redis)
@@ -164,39 +163,7 @@ export async function middleware(request: NextRequest) {
       return rateLimitResponse;
     }
   }
-  
-  // Vérifier la protection CSRF pour les méthodes POST, PUT, DELETE, PATCH
-  // Ceci s'applique uniquement aux routes API qui ne sont pas des webhooks
-  if (['POST', 'PUT', 'DELETE', 'PATCH'].includes(request.method) && 
-      request.nextUrl.pathname.startsWith('/api') && 
-      !request.nextUrl.pathname.startsWith('/api/webhooks')) {
-    
-    // Désactiver temporairement la validation CSRF pour les routes sensibles (débogage)
-    if (request.nextUrl.pathname === '/api/auth/logout' || 
-        request.nextUrl.pathname === '/api/auth/login') {
-      return NextResponse.next();
-    }
-    
-    // Cette partie a été supprimée car nous n'utilisons plus de token de débogage
-    // avec la nouvelle approche CSRF basée sur le serveur
-    
-    // Valider le token CSRF
-    // Nous pouvons passer une chaîne vide comme deuxième paramètre puisque notre implémentation
-    // actualisée n'utilise pas réellement ce paramètre, mais le vérifie en interne
-    const isValidCsrf = await validateCsrfToken(request, '');
-    
-    // Si le token est invalide, bloquer la requête
-    if (!isValidCsrf) {
-      return NextResponse.json(
-        { 
-          error: 'Protection CSRF: token invalide ou manquant', 
-          details: 'Pour des raisons de sécurité, cette requête a été bloquée. Veuillez recharger la page et réessayer.'
-        },
-        { status: 403 }
-      );
-    }
-  }
-  
+
   // Routes protégées nécessitant une authentification
   const protectedPaths = [
     '/compte',


### PR DESCRIPTION
## Summary
- remove CSRF validation from middleware
- adjust unit tests for middleware and promo code hook
- polyfill dom APIs for tests

## Testing
- `pnpm test`