### PR TITLE
[Fix] update API calls with CSRF and absolute URL

### DIFF
--- a/src/app/api/user/addresses/route.ts
+++ b/src/app/api/user/addresses/route.ts
@@ -24,7 +24,7 @@ interface Address {
 export async function GET(request: NextRequest) {
   try {
     // 1. Authentifier l'utilisateur
-    const authResponse = await fetch('/api/auth/me', {
+    const authResponse = await fetch(`${process.env.BACKEND_INTERNAL_URL}/api/auth/me`, {
       headers: {
         'Cookie': request.headers.get('cookie') || ''
       }
@@ -115,7 +115,7 @@ export async function POST(request: NextRequest) {
     const addressData = sanitizeObject(validation.data);
     
     // 3. Authentifier l'utilisateur et récupérer le token
-    const authResponse = await fetch('/api/auth/me', {
+    const authResponse = await fetch(`${process.env.BACKEND_INTERNAL_URL}/api/auth/me`, {
       headers: {
         'Cookie': request.headers.get('cookie') || ''
       }
@@ -269,7 +269,7 @@ export async function PATCH(request: NextRequest) {
     }
     
     // 3. Authentifier l'utilisateur et récupérer le token
-    const authResponse = await fetch('/api/auth/me', {
+    const authResponse = await fetch(`${process.env.BACKEND_INTERNAL_URL}/api/auth/me`, {
       headers: {
         'Cookie': request.headers.get('cookie') || ''
       }
@@ -429,7 +429,7 @@ export async function DELETE(request: NextRequest) {
     }
     
     // 2. Authentifier l'utilisateur et récupérer le token
-    const authResponse = await fetch('/api/auth/me', {
+    const authResponse = await fetch(`${process.env.BACKEND_INTERNAL_URL}/api/auth/me`, {
       headers: {
         'Cookie': request.headers.get('cookie') || ''
       }

--- a/src/app/compte/adresses/page.tsx
+++ b/src/app/compte/adresses/page.tsx
@@ -261,7 +261,8 @@ export default function AddressesPage() {
         credentials: 'include',
         headers: {
           'Content-Type': 'application/json'
-        }
+        },
+        withCsrf: true
       });
       
       if (!meResponse.ok) {
@@ -342,7 +343,8 @@ export default function AddressesPage() {
         headers: {
           'Content-Type': 'application/json'
         },
-        body: JSON.stringify(formAddress)
+        body: JSON.stringify(formAddress),
+        withCsrf: true
       });
       
       if (response.ok) {
@@ -392,7 +394,8 @@ export default function AddressesPage() {
         credentials: 'include',
         headers: {
           'Content-Type': 'application/json'
-        }
+        },
+        withCsrf: true
       });
       
       if (!meResponse.ok) {
@@ -438,7 +441,8 @@ export default function AddressesPage() {
         credentials: 'include',
         headers: {
           'Content-Type': 'application/json'
-        }
+        },
+        withCsrf: true
       });
       
       if (response.ok) {
@@ -477,7 +481,8 @@ export default function AddressesPage() {
         credentials: 'include',
         headers: {
           'Content-Type': 'application/json'
-        }
+        },
+        withCsrf: true
       });
       
       if (!meResponse.ok) {
@@ -526,7 +531,8 @@ export default function AddressesPage() {
         credentials: 'include',
         headers: {
           'Content-Type': 'application/json'
-        }
+        },
+        withCsrf: true
       });
       
       if (response.ok) {

--- a/src/app/compte/client-dashboard.tsx
+++ b/src/app/compte/client-dashboard.tsx
@@ -138,6 +138,7 @@ export default function ClientDashboard({ initialUser }: { initialUser: User }) 
           'Content-Type': 'application/json',
         },
         body: JSON.stringify(newUserData),
+        withCsrf: true
       });
       
       const responseData = await response.json();

--- a/src/app/compte/verifier-email/page.tsx
+++ b/src/app/compte/verifier-email/page.tsx
@@ -30,6 +30,7 @@ function VerifierEmailContent() {
             'Content-Type': 'application/json',
           },
           body: JSON.stringify({ token }),
+          withCsrf: true
         });
 
         const data = await response.json();

--- a/src/app/connexion/page.tsx
+++ b/src/app/connexion/page.tsx
@@ -169,7 +169,7 @@ function LoginForm() {
         email: formData.email,
         password: formData.password,
         collection: 'customers'
-      });
+      }, { withCsrf: true });
       
       const data = response.data;
 

--- a/src/app/inscription/page.tsx
+++ b/src/app/inscription/page.tsx
@@ -72,6 +72,7 @@ function RegisterForm() {
           password: formData.password,
           gdprConsent: formData.gdprConsent
         }),
+        withCsrf: true
       });
 
       const data = await response.json();

--- a/src/app/mot-de-passe-oublie/page.tsx
+++ b/src/app/mot-de-passe-oublie/page.tsx
@@ -26,6 +26,7 @@ function ForgotPasswordForm() {
           email,
           collection: 'customers'
         }),
+        withCsrf: true
       });
 
       const data = await response.json();

--- a/src/app/panier/hooks/useCheckout.ts
+++ b/src/app/panier/hooks/useCheckout.ts
@@ -167,6 +167,7 @@ export default function useCheckout(
 
       // Faire la requête via httpClient pour éviter les problèmes CORS
       const response = await httpClient.post('/payment/create', checkoutData, {
+        withCsrf: true,
         headers: {
           ...(token ? { Authorization: `Bearer ${token}` } : {})
         }

--- a/src/app/panier/hooks/useLoyaltyBenefits.ts
+++ b/src/app/panier/hooks/useLoyaltyBenefits.ts
@@ -47,6 +47,7 @@ export default function useLoyaltyBenefits(
           shippingCost: country === 'Belgique' ? 10 : cart.subtotal >= 49 ? 0 : 4.95,
           items: cart.items
         }, {
+          withCsrf: true,
           headers
         });
 

--- a/src/app/panier/hooks/usePromoCode.ts
+++ b/src/app/panier/hooks/usePromoCode.ts
@@ -80,7 +80,7 @@ export default function usePromoCode(
         cartTotal: cart.subtotal,
         shippingCost,
         items: itemsWithCat
-      });
+      }, { withCsrf: true });
 
       if (result.success && result.valid) {
         let message: string = result.message || '';

--- a/src/app/reinitialiser-mot-de-passe/[token]/page.tsx
+++ b/src/app/reinitialiser-mot-de-passe/[token]/page.tsx
@@ -86,6 +86,7 @@ export default function ResetPasswordPage() {
           newPassword: password,
           collection: 'customers'
         }),
+        withCsrf: true
       });
 
       const data = await response.json();

--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -56,7 +56,7 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
       setLoading(true);
       setError(null);
 
-      const { data, status } = await httpClient.get('/auth/me');
+      const { data, status } = await httpClient.get('/auth/me', { withCsrf: true });
 
       if (status === 401) {
         setIsAuthenticated(false);
@@ -89,7 +89,7 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
   const logout = useCallback(async () => {
     try {
       setLoading(true);
-      await httpClient.post('/auth/logout');
+      await httpClient.post('/auth/logout', undefined, { withCsrf: true });
       setIsAuthenticated(false);
       setUser(null);
       window.dispatchEvent(new CustomEvent('auth-change', { detail: { isLoggedIn: false } }));


### PR DESCRIPTION
## Summary
- use absolute backend url for server-side auth fetches
- add `withCsrf: true` to client mutations and sensitive requests

## Testing
- `pnpm lint` *(fails: next not found)*
- `pnpm test` *(fails: jest not found)*